### PR TITLE
Bug 1294725 - Fairphone 2 needs special caf repo revision=gerard-majax

### DIFF
--- a/include/binder/Binder.h
+++ b/include/binder/Binder.h
@@ -17,7 +17,13 @@
 #ifndef ANDROID_BINDER_H
 #define ANDROID_BINDER_H
 
+#if __cplusplus >= 201103L
+#include <atomic>
+typedef std::atomic<uintptr_t> atomic_uintptr_t;
+#else
 #include <stdatomic.h>
+#endif
+
 #include <stdint.h>
 #include <binder/IBinder.h>
 


### PR DESCRIPTION
Include <atomic> for C++11 builds
The C header file <stdatomic.h> is not compatible with C++. For C++11
builds, we include <atomic> instead. Compiler implementors guarantee
compatibility of memory models and data structures.
